### PR TITLE
Fix typo in contributte/api URL

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -26,7 +26,7 @@ The middlewares / relay conception is a strong pattern with many benefits.
 First of all you have to register one of the given extensions ([CompilerExtensions](https://api.nette.org/2.4/Nette.DI.CompilerExtension.html)))in your config file. 
 There are basically 2 single modes. 
 
-**Standalone mode** is best suitable for new projects with middleware architecture, works great with [contributte/api](https://github.com/conrtibutte/api).
+**Standalone mode** is best suitable for new projects with middleware architecture, works great with [contributte/api](https://github.com/contributte/api).
 
 **Nette mode** is for integration to already running Nette projects, it overrides `Nette\Application\Application`.
 


### PR DESCRIPTION
There is a typo in a link to [contributte/api](https://github.com/contributte/api) in README.md.