### PR TITLE
Method override middleware

### DIFF
--- a/src/MethodOverrideMiddleware.php
+++ b/src/MethodOverrideMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Contributte\Middlewares;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MethodOverrideMiddleware extends BaseMiddleware
+{
+	const OVERRIDE_HEADER = 'X-HTTP-Method-Override';
+
+	/**
+	 * @param ServerRequestInterface $request
+	 * @param ResponseInterface $response
+	 * @param callable $next
+	 * @return ResponseInterface
+	 */
+	public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+	{
+		if ($request->hasHeader(self::OVERRIDE_HEADER) && $request->getHeader(self::OVERRIDE_HEADER)[0] !== '') {
+			$request = $request->withMethod($request->getHeader(self::OVERRIDE_HEADER)[0]);
+		}
+
+		return $next($request, $response);
+	}
+}

--- a/src/MethodOverrideMiddleware.php
+++ b/src/MethodOverrideMiddleware.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class MethodOverrideMiddleware extends BaseMiddleware
 {
+
 	const OVERRIDE_HEADER = 'X-HTTP-Method-Override';
 
 	/**
@@ -23,4 +24,5 @@ class MethodOverrideMiddleware extends BaseMiddleware
 
 		return $next($request, $response);
 	}
+
 }

--- a/tests/cases/MethodOverrideMiddleware.phpt
+++ b/tests/cases/MethodOverrideMiddleware.phpt
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests;
+
+use Contributte\Middlewares\MethodOverrideMiddleware;
+use Contributte\Psr7\Psr7ResponseFactory;
+use Contributte\Psr7\Psr7ServerRequestFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+test(function () {
+	$middleware = new MethodOverrideMiddleware();
+
+	$request = Psr7ServerRequestFactory::fromGlobal()
+		->withMethod('POST')
+		->withHeader(MethodOverrideMiddleware::OVERRIDE_HEADER, 'PUT');
+
+	$middleware(
+		$request,
+		Psr7ResponseFactory::fromGlobal(),
+		function (ServerRequestInterface $req, ResponseInterface $res) {
+			Assert::equal('PUT', $req->getMethod());
+		});
+});
+
+test(function () {
+	$middleware = new MethodOverrideMiddleware();
+
+	$request = Psr7ServerRequestFactory::fromGlobal()
+		->withMethod('POST')
+		->withHeader(MethodOverrideMiddleware::OVERRIDE_HEADER, '');
+
+	$middleware(
+		$request,
+		Psr7ResponseFactory::fromGlobal(),
+		function (ServerRequestInterface $req, ResponseInterface $res) {
+			Assert::equal('POST', $req->getMethod());
+		});
+});
+
+test(function () {
+	$middleware = new MethodOverrideMiddleware();
+
+	$request = Psr7ServerRequestFactory::fromGlobal()
+		->withMethod('DELETE');
+
+	$middleware(
+		$request,
+		Psr7ResponseFactory::fromGlobal(),
+		function (ServerRequestInterface $req, ResponseInterface $res) {
+			Assert::equal('DELETE', $req->getMethod());
+		});
+});


### PR DESCRIPTION
Allow using X-HTTP-Method-Override header to override HTTP method. 