### PR TITLE
Fix bug in MiddlewareApplication.php, multiple settings of content-type header

### DIFF
--- a/src/Application/MiddlewareApplication.php
+++ b/src/Application/MiddlewareApplication.php
@@ -54,7 +54,7 @@ class MiddlewareApplication extends AbstractApplication
 		$name = str_replace(' ', '-', $name);
 		foreach ($values as $value) {
 			// never send multiple content-type headers
-			if (preg_match("/content-type/i", $name)) {
+			if (preg_match('/content-type/i', $name)) {
 				header(sprintf('%s: %s', $name, $value));
 			}
 			else {

--- a/src/Application/MiddlewareApplication.php
+++ b/src/Application/MiddlewareApplication.php
@@ -53,7 +53,13 @@ class MiddlewareApplication extends AbstractApplication
 		$name = ucwords($name);
 		$name = str_replace(' ', '-', $name);
 		foreach ($values as $value) {
-			header(sprintf('%s: %s', $name, $value), false);
+			// never send multiple content-type headers
+			if (preg_match("/content-type/i", $name)) {
+				header(sprintf('%s: %s', $name, $value));				
+			}
+			else {
+				header(sprintf('%s: %s', $name, $value), false);				
+			}
 		}
 	}
 

--- a/src/Application/MiddlewareApplication.php
+++ b/src/Application/MiddlewareApplication.php
@@ -55,10 +55,10 @@ class MiddlewareApplication extends AbstractApplication
 		foreach ($values as $value) {
 			// never send multiple content-type headers
 			if (preg_match("/content-type/i", $name)) {
-				header(sprintf('%s: %s', $name, $value));				
+				header(sprintf('%s: %s', $name, $value));
 			}
 			else {
-				header(sprintf('%s: %s', $name, $value), false);				
+				header(sprintf('%s: %s', $name, $value), false);
 			}
 		}
 	}


### PR DESCRIPTION
Some 3rd parties libraries, can set content-type at the beginning of script.

Like Nette

https://github.com/nette/http/blob/master/src/Bridges/HttpDI/HttpExtension.php#L38

Content-Type cant be set multiple times, therefore the replace parameter should be true.

In other case the browser will crash during the finishing request.