### PR TITLE
Bump psr7-http-message to 0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=7.2",
     "contributte/di": "^0.4.0",
-    "contributte/psr7-http-message": "^0.6.0"
+    "contributte/psr7-http-message": "^0.7.0"
   },
   "require-dev": {
     "nette/application": "~3.0.0",


### PR DESCRIPTION
apitte/core requires psr7-http-message 0.7 
apitte/middlewares requires apitte/core and contributte/middlewares which is locked to psr7-http-message 0.6. It needs to be open for psr7-http-message 0.7