### PR TITLE
Fix logging in TryCatchMiddleware.

### DIFF
--- a/src/TryCatchMiddleware.php
+++ b/src/TryCatchMiddleware.php
@@ -62,7 +62,7 @@ class TryCatchMiddleware implements IMiddleware
 			return;
 		}
 
-		$this->logger->log($throwable->getMessage(), $this->logLevel);
+		$this->logger->log($this->logLevel, $throwable->getMessage());
 	}
 
 }


### PR DESCRIPTION
[Logger](https://github.com/php-fig/log/blob/master/Psr/Log/LoggerInterface.php) has interface
```php
    /**
     * Logs with an arbitrary level.
     *
     * @param mixed   $level
     * @param string  $message
     * @param mixed[] $context
     *
     * @return void
     *
     * @throws \Psr\Log\InvalidArgumentException
     */
    public function log($level, $message, array $context = array());
```